### PR TITLE
Changed frame time to match 512 x 32 NRS subarray.

### DIFF
--- a/generate_frame.py
+++ b/generate_frame.py
@@ -36,7 +36,7 @@ plt.show()
 
 # Now, generate image with a ramp:
 slope = 25. # Slope is in electrons per second
-frametime = 0.90200 # Frame time is in seconds
+frametime = 0.226 # Frame time is in seconds
 ngroups = 5
 gain = 1.42 # Gain is in e/adu
 
@@ -59,6 +59,3 @@ for i in range(ngroups):
     plt.imshow(simulated_groups[i, :, :])
 
 plt.show()
-
-
-


### PR DESCRIPTION
Changed frametime for 512 x 32 subarray to 0.226 seconds based on table 2 at https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-observing-modes/nirspec-bright-object-time-series-spectroscopy